### PR TITLE
fix: .htaccess

### DIFF
--- a/scripts/w3id.org/.htaccess
+++ b/scripts/w3id.org/.htaccess
@@ -71,7 +71,7 @@ RewriteRule ^docs/?(.*)$ %{ENV:DOCS}/$1 [R=303,L]
 
 # Redirect /github to GitHub project
 RewriteCond %{REQUEST_URI} ^/github/?(.*)$
-RewriteRule ^github/?(.*)$ %{ENV:WEBSITE}/$1 [R=303,L]
+RewriteRule ^github/?(.*)$ %{ENV:GH_PROJECT}/$1 [R=303,L]
 
 RewriteCond %{ENV:ONTOSPY} ^true$
 RewriteRule ^classes/([A-Z][a-zA-Z0-9_]*)$ %{ENV:DOCS}/ontospy/class-%{ENV:ONTO}$1.html [R=303,L]

--- a/scripts/w3id.org/.htaccess
+++ b/scripts/w3id.org/.htaccess
@@ -23,9 +23,9 @@ RewriteCond %{ENV:EXT} ^$
 RewriteCond %{HTTP_ACCEPT} ^(.*[,;])?(application/ld\+json)([,;].*)?$
 RewriteRule ^ - [E=EXT:jsonld]
 
-# RDF/XML (just xml and text/xml is too broad (browsers usually include by default))
+# RDF/XML
 RewriteCond %{ENV:EXT} ^$
-RewriteCond %{HTTP_ACCEPT} ^(application/rdf\+xml|application/xml|text/xml)?$
+RewriteCond %{HTTP_ACCEPT} ^(application/rdf\+xml|application/xml|text/xml|xml)?$
 RewriteRule ^ - [E=EXT:owl]
 
 # Turtle variants

--- a/scripts/w3id.org/.htaccess
+++ b/scripts/w3id.org/.htaccess
@@ -42,25 +42,25 @@ RewriteRule ^ - [E=EXT:nt]
 # Website redirect when no format requested
 
 RewriteCond %{ENV:EXT} ^$
-RewriteRule ^/?$ %{ENV:WEBSITE} [R=302,L]
+RewriteRule ^/?$ %{ENV:WEBSITE} [R=303,L]
 
 # Redirect when root requested with content negotiation
 RewriteCond %{ENV:EXT} .
-RewriteRule ^/?$ %{ENV:FILE_IRI}/latest/%{ENV:ONTO}.%{ENV:EXT} [R=302,L]
+RewriteRule ^/?$ %{ENV:FILE_IRI}/latest/%{ENV:ONTO}.%{ENV:EXT} [R=303,L]
 
 # Redirect when the requested path inside this directory is `versions/latest`
 RewriteCond %{ENV:EXT} .
-RewriteRule ^versions/latest/?$ %{ENV:FILE_IRI}/latest/%{ENV:ONTO}.%{ENV:EXT} [R=302,L]
+RewriteRule ^versions/latest/?$ %{ENV:FILE_IRI}/latest/%{ENV:ONTO}.%{ENV:EXT} [R=303,L]
 
 # Redirect for specific versions
 RewriteCond %{ENV:EXT} .
-RewriteRule ^versions/([0-9]+\.[0-9]+\.[0-9]+)/?$ %{ENV:FILE_IRI}/$1/%{ENV:ONTO}.%{ENV:EXT} [R=302,L]
+RewriteRule ^versions/([0-9]+\.[0-9]+\.[0-9]+)/?$ %{ENV:FILE_IRI}/$1/%{ENV:ONTO}.%{ENV:EXT} [R=303,L]
 
 # Docs redirect
-RewriteRule ^docs/?$ %{ENV:DOCS} [R=302,L]
+RewriteRule ^docs/?$ %{ENV:DOCS} [R=303,L]
 
 # Github redirect
-RewriteRule ^github/?$ %{ENV:GH_PROJECT} [R=302,L]
+RewriteRule ^github/?$ %{ENV:GH_PROJECT} [R=303,L]
 
 # Redirect for Classes if ONTOSPY is true
 RewriteCond %{ENV:ONTOSPY} ^true$

--- a/scripts/w3id.org/.htaccess
+++ b/scripts/w3id.org/.htaccess
@@ -73,11 +73,9 @@ RewriteRule ^docs/?(.*)$ %{ENV:DOCS}/$1 [R=303,L]
 RewriteCond %{REQUEST_URI} ^/github/?(.*)$
 RewriteRule ^github/?(.*)$ %{ENV:WEBSITE}/$1 [R=303,L]
 
-# Redirect Class and prop to OntoSpy documentation
-RewriteCond %{REQUEST_URI} ^/([A-Z]+.*)$
 RewriteCond %{ENV:ONTOSPY} ^true$
-RewriteRule ^([A-Z]+.*)$ ${ENV:DOCS}/ontospy/class-%{ENV:ONTO}$1.html [R=303,L]
+RewriteRule ^classes/([A-Z][a-zA-Z0-9_]*)$ %{ENV:DOCS}/ontospy/class-%{ENV:ONTO}$1.html [R=303,L]
 
-RewriteCond %{REQUEST_URI} ^/([a-z]+.*)$
+# Redirect for Properties if ONTOSPY is true
 RewriteCond %{ENV:ONTOSPY} ^true$
-RewriteRule ^([a-z]+.*)$ ${ENV:DOCS}/ontospy/prop-%{ENV:ONTO}$1.html [R=303,L]
+RewriteRule ^properties/([a-z][a-zA-Z0-9_]*)$ %{ENV:DOCS}/ontospy/prop-%{ENV:ONTO}$1.html [R=303,L]

--- a/scripts/w3id.org/.htaccess
+++ b/scripts/w3id.org/.htaccess
@@ -3,7 +3,6 @@ Options -MultiViews
 
 RewriteEngine On
 
-
 RewriteRule ^ - [E=ONTO:testo]
 RewriteRule ^ - [E=ONTO_IRI:https://w3id.org/%{ENV:ONTO}/]
 RewriteRule ^ - [E=GH_USER:micheldumontier]
@@ -17,57 +16,68 @@ RewriteRule ^ - [E=DOCS:%{ENV:WEBSITE}/docs]
 RewriteRule ^ - [E=VERSIONS:versions]
 RewriteRule ^ - [E=FILE_IRI:%{ENV:WEBSITE}/%{ENV:VERSIONS}]
 
-### Content negotiation for ontology formats
-# JSON-LD
-RewriteCond %{ENV:EXT} ^$
-RewriteCond %{HTTP_ACCEPT} ^(.*[,;])?(application/ld\+json)([,;].*)?$
+# Content negotiation for ontology formats
+## JSON-LD
+RewriteCond %{HTTP_ACCEPT} application/ld+json
 RewriteRule ^ - [E=EXT:jsonld]
 
-# RDF/XML
-RewriteCond %{ENV:EXT} ^$
-RewriteCond %{HTTP_ACCEPT} ^(application/rdf\+xml|application/xml|text/xml|xml)?$
+## RDF/XML
+RewriteCond %{HTTP_ACCEPT} "application/xml" [OR]
+RewriteCond %{HTTP_ACCEPT} "text/xml" [OR]
+RewriteCond %{HTTP_ACCEPT} "xml" [OR]
+RewriteCond %{HTTP_ACCEPT} "application/rdf\+xml"
 RewriteRule ^ - [E=EXT:owl]
 
-# Turtle variants
-RewriteCond %{ENV:EXT} ^$
-RewriteCond %{HTTP_ACCEPT} ^(.*[,;])?(text/turtle|text/ttl|application/turtle|application/x-turtle)([,;].*)?$
+## Turtle variants
+RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} text/ttl [OR]
+RewriteCond %{HTTP_ACCEPT} application/turtle [OR]
+RewriteCond %{HTTP_ACCEPT} application/x-turtle
 RewriteRule ^ - [E=EXT:ttl]
 
-# N-Triples
-RewriteCond %{ENV:EXT} ^$
-RewriteCond %{HTTP_ACCEPT} ^(.*[,;])?(application/n-triples)([,;].*)?$
+## N-Triples
+RewriteCond %{HTTP_ACCEPT} application/n-triples
 RewriteRule ^ - [E=EXT:nt]
 
-
-# Website redirect when no format requested
-
-RewriteCond %{ENV:EXT} ^$
-RewriteRule ^/?$ %{ENV:WEBSITE} [R=303,L]
-
-# Redirect when root requested with content negotiation
+# Map requests to target resources
+RewriteCond %{REQUEST_URI} ^/?$
 RewriteCond %{ENV:EXT} .
-RewriteRule ^/?$ %{ENV:FILE_IRI}/latest/%{ENV:ONTO}.%{ENV:EXT} [R=303,L]
+RewriteRule ^ - [E=TARGET:%{ENV:FILE_IRI}/latest/%{ENV:ONTO}.%{ENV:EXT}]
 
-# Redirect when the requested path inside this directory is `versions/latest`
+
+# Latest version with format
+RewriteCond %{REQUEST_URI} ^/versions/latest/?$
 RewriteCond %{ENV:EXT} .
-RewriteRule ^versions/latest/?$ %{ENV:FILE_IRI}/latest/%{ENV:ONTO}.%{ENV:EXT} [R=303,L]
+RewriteRule ^versions/latest/?$ - [E=TARGET:%{ENV:FILE_IRI}/latest/%{ENV:ONTO}.%{ENV:EXT}]
 
-# Redirect for specific versions
+# Specific version with format
+
+RewriteCond %{REQUEST_URI} ^/versions/(latest|[0-9]+\.[0-9]+\.[0-9]+)/?$
 RewriteCond %{ENV:EXT} .
-RewriteRule ^versions/([0-9]+\.[0-9]+\.[0-9]+)/?$ %{ENV:FILE_IRI}/$1/%{ENV:ONTO}.%{ENV:EXT} [R=303,L]
+RewriteRule ^versions/(latest|[0-9]+\.[0-9]+\.[0-9]+)/?$ - [E=TARGET:%{ENV:FILE_IRI}/$1/%{ENV:ONTO}.%{ENV:EXT}]
 
-# Docs redirect
-RewriteRule ^docs/?$ %{ENV:DOCS} [R=303,L]
+# Redirect to target if set
+RewriteCond %{ENV:TARGET} .
+RewriteRule ^ %{ENV:TARGET} [R=303,L]
 
-# Github redirect
-RewriteRule ^github/?$ %{ENV:GH_PROJECT} [R=303,L]
+# Default to Website if no target format requested
+RewriteCond %{ENV:TARGET} !.
+RewriteCond %{ENV:EXT} !.
+RewriteRule ^/?$ %{ENV:WEBSITE}  [R=303,L]
 
-# Redirect for Classes if ONTOSPY is true
+# Redirect /docs to documentation
+RewriteCond %{REQUEST_URI} ^/docs/?(.*)$
+RewriteRule ^docs/?(.*)$ %{ENV:DOCS}/$1 [R=303,L]
+
+# Redirect /github to GitHub project
+RewriteCond %{REQUEST_URI} ^/github/?(.*)$
+RewriteRule ^github/?(.*)$ %{ENV:WEBSITE}/$1 [R=303,L]
+
+# Redirect Class and prop to OntoSpy documentation
+RewriteCond %{REQUEST_URI} ^/([A-Z]+.*)$
 RewriteCond %{ENV:ONTOSPY} ^true$
-RewriteRule ^classes/(.*)$ %{ENV:DOCS}/ontospy/class-%{ENV:ONTO}$1.html [R=303,L]
+RewriteRule ^([A-Z]+.*)$ ${ENV:DOCS}/ontospy/class-%{ENV:ONTO}$1.html [R=303,L]
 
-# Redirect for Properties if ONTOSPY is true
+RewriteCond %{REQUEST_URI} ^/([a-z]+.*)$
 RewriteCond %{ENV:ONTOSPY} ^true$
-RewriteRule ^properties/(.*)$ %{ENV:DOCS}/ontospy/prop-%{ENV:ONTO}$1.html [R=303,L]
-
-# End of file
+RewriteRule ^([a-z]+.*)$ ${ENV:DOCS}/ontospy/prop-%{ENV:ONTO}$1.html [R=303,L]

--- a/scripts/w3id.org/.htaccess
+++ b/scripts/w3id.org/.htaccess
@@ -3,6 +3,7 @@ Options -MultiViews
 
 RewriteEngine On
 
+
 RewriteRule ^ - [E=ONTO:testo]
 RewriteRule ^ - [E=ONTO_IRI:https://w3id.org/%{ENV:ONTO}/]
 RewriteRule ^ - [E=GH_USER:micheldumontier]
@@ -18,58 +19,55 @@ RewriteRule ^ - [E=FILE_IRI:%{ENV:WEBSITE}/%{ENV:VERSIONS}]
 
 ### Content negotiation for ontology formats
 # JSON-LD
-RewriteCond %{HTTP_ACCEPT} application/ld+json
+RewriteCond %{ENV:EXT} ^$
+RewriteCond %{HTTP_ACCEPT} ^(.*[,;])?(application/ld\+json)([,;].*)?$
 RewriteRule ^ - [E=EXT:jsonld]
 
-# RDF/XML
-RewriteCond %{HTTP_ACCEPT} "application/xml" [OR]
-RewriteCond %{HTTP_ACCEPT} "text/xml" [OR]
-RewriteCond %{HTTP_ACCEPT} "xml" [OR]
-RewriteCond %{HTTP_ACCEPT} "application/rdf\+xml"
+# RDF/XML (just xml and text/xml is too broad (browsers usually include by default))
+RewriteCond %{ENV:EXT} ^$
+RewriteCond %{HTTP_ACCEPT} ^(application/rdf\+xml|application/xml|text/xml)?$
 RewriteRule ^ - [E=EXT:owl]
 
 # Turtle variants
-RewriteCond %{HTTP_ACCEPT} text/turtle [OR]
-RewriteCond %{HTTP_ACCEPT} text/ttl [OR]
-RewriteCond %{HTTP_ACCEPT} application/turtle [OR]
-RewriteCond %{HTTP_ACCEPT} application/x-turtle
+RewriteCond %{ENV:EXT} ^$
+RewriteCond %{HTTP_ACCEPT} ^(.*[,;])?(text/turtle|text/ttl|application/turtle|application/x-turtle)([,;].*)?$
 RewriteRule ^ - [E=EXT:ttl]
 
 # N-Triples
-RewriteCond %{HTTP_ACCEPT} application/n-triples
+RewriteCond %{ENV:EXT} ^$
+RewriteCond %{HTTP_ACCEPT} ^(.*[,;])?(application/n-triples)([,;].*)?$
 RewriteRule ^ - [E=EXT:nt]
 
-### Map requests to target resources
-RewriteCond %{REQUEST_URI} ^/?$
+
+# Website redirect when no format requested
+
+RewriteCond %{ENV:EXT} ^$
+RewriteRule ^/?$ %{ENV:WEBSITE} [R=302,L]
+
+# Redirect when root requested with content negotiation
 RewriteCond %{ENV:EXT} .
-RewriteRule ^ - [E=TARGET:%{ENV:FILE_IRI}/latest/%{ENV:ONTO}.%{ENV:EXT}]
+RewriteRule ^/?$ %{ENV:FILE_IRI}/latest/%{ENV:ONTO}.%{ENV:EXT} [R=302,L]
 
-RewriteCond %{REQUEST_URI} ^/versions/(latest|[0-9]+\.[0-9]+\.[0-9]+)/?$
+# Redirect when the requested path inside this directory is `versions/latest`
 RewriteCond %{ENV:EXT} .
-RewriteRule ^versions/(latest|[0-9]+\.[0-9]+\.[0-9]+)/?$ - [E=TARGET:%{ENV:FILE_IRI}/$1/%{ENV:ONTO}.%{ENV:EXT}]
+RewriteRule ^versions/latest/?$ %{ENV:FILE_IRI}/latest/%{ENV:ONTO}.%{ENV:EXT} [R=302,L]
 
-# Redirect to target if set
-RewriteCond %{ENV:TARGET} .
-RewriteRule ^ %{ENV:TARGET} [R=303,L]
+# Redirect for specific versions
+RewriteCond %{ENV:EXT} .
+RewriteRule ^versions/([0-9]+\.[0-9]+\.[0-9]+)/?$ %{ENV:FILE_IRI}/$1/%{ENV:ONTO}.%{ENV:EXT} [R=302,L]
 
-# Default to Website if no target format requested
-RewriteCond %{ENV:TARGET} !.
-RewriteCond %{ENV:EXT} !.
-RewriteRule ^/?$ %{ENV:WEBSITE}  [R=303,L]
+# Docs redirect
+RewriteRule ^docs/?$ %{ENV:DOCS} [R=302,L]
 
-# Redirect /docs to documentation
-RewriteCond %{REQUEST_URI} ^/docs/?(.*)$
-RewriteRule ^docs/?(.*)$ %{ENV:DOCS}/$1 [R=303,L]
+# Github redirect
+RewriteRule ^github/?$ %{ENV:GH_PROJECT} [R=302,L]
 
-# Redirect /github to GitHub project
-RewriteCond %{REQUEST_URI} ^/github/?(.*)$
-RewriteRule ^github/?(.*)$ %{ENV:WEBSITE}/$1 [R=303,L]
-
-# Redirect Class and prop to OntoSpy documentation
-RewriteCond %{REQUEST_URI} ^/([A-Z]+.*)$
+# Redirect for Classes if ONTOSPY is true
 RewriteCond %{ENV:ONTOSPY} ^true$
-RewriteRule ^([A-Z]+.*)$ ${ENV:DOCS}/ontospy/class-%{ENV:ONTO}$1.html [R=303,L]
+RewriteRule ^classes/(.*)$ %{ENV:DOCS}/ontospy/class-%{ENV:ONTO}$1.html [R=303,L]
 
-RewriteCond %{REQUEST_URI} ^/([a-z]+.*)$
+# Redirect for Properties if ONTOSPY is true
 RewriteCond %{ENV:ONTOSPY} ^true$
-RewriteRule ^([a-z]+.*)$ ${ENV:DOCS}/ontospy/prop-%{ENV:ONTO}$1.html [R=303,L]
+RewriteRule ^properties/(.*)$ %{ENV:DOCS}/ontospy/prop-%{ENV:ONTO}$1.html [R=303,L]
+
+# End of file

--- a/scripts/w3id.org/.htaccess
+++ b/scripts/w3id.org/.htaccess
@@ -9,7 +9,7 @@ RewriteRule ^ - [E=GH_USER:micheldumontier]
 RewriteRule ^ - [E=GH_REPO:ontostart]
 RewriteRule ^ - [E=GH_BRANCH:testo]
 RewriteRule ^ - [E=ONTOSPY:true]
-RewriteRule ^ - [E=GH_PROJECT:https://%{ENV:GH_USER}.github.com/%{ENV:GH_REPO}/%{ENV:GH_BRANCH}]
+RewriteRule ^ - [E=GH_PROJECT:https://github.com/%{ENV:GH_USER}/%{ENV:GH_REPO}/tree/%{ENV:GH_BRANCH}]
 RewriteRule ^ - [E=WEBSITE:https://%{ENV:GH_USER}.github.io/%{ENV:GH_REPO}/%{ENV:GH_BRANCH}]
 RewriteRule ^ - [E=DOCS:%{ENV:WEBSITE}/docs]
 


### PR DESCRIPTION
- Removed unnecessary RewriteCond rules.
  - The first part of the RewriteRule is used for both validation and path parsing.
- Fixed GitHub path: it was redirecting to the website instead of the GitHub page.
- Checked OntoSpy and confirmed that OntoSpy properties can contain uppercase letters 
  - Separated them by path.
  - This also lowers the risk of collission with other redirects
- Removed TARGET variable. I couldn’t make Apache use it for redirects.

Though some of the redirects doesn't work. You can see the redirects that do not work below:

`http://localhost:8080/docs` -> `https://micheldumontier.github.io/ontostart/testo/docs/`

---------
Also, I have some questions about the branch forwarding you mentioned. I wasn’t fully focused because I was eating (sorry :p).
As it is now, it doesn’t support branch-based redirects.

If you want that, I think we have to change the path layout from this:

```
https://w3id.org/%{ENV:ONTO}/
```

to this

```
https://w3id.org/%{ENV:ONTO}/%{GH_BRANCH}
```

And then add the following to the .htaccess file to grab the branch information:
```
RewriteRule ^/([A-Za-z0-9_\-]+)/?$ - [E=GH_BRANCH:$1]
```

And we have to adjust other redirects as well